### PR TITLE
[WIP]出品画面マークアップ

### DIFF
--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -68,15 +68,27 @@
           font-weight: bold;
         }
         &__image{
+          text-align:center;
           &__explain{
             display: flex;
             justify-content: center;
             padding-bottom:0px;
-            p.name{
+            p.image{
               @include title;
             }
             p.absolute{
               @include absolute;
+            }
+          }
+          .hidden-content{
+            width:660px;
+            height:150px;
+            background-color: rgb(244, 244, 244);
+            border:1px dotted rgb(182, 179, 179);
+            margin-bottom:50px;
+            p.dragdrop{
+              font-size:12px;
+              margin-top:40px;
             }
           }
           p.img-explain{
@@ -296,6 +308,33 @@
             @include btn;
           }
         }
+      }
+    }
+  }
+  .edit__footer{
+    background-color: rgb(244, 244, 244);
+    &__box{
+      border-top: 1px solid rgb(202, 199, 199);
+      display: flex;
+      justify-content:center;
+      
+      p.footer-rule{
+        margin:50px 10px;
+        font-size:12px;
+      }
+    }
+    &__img{
+      text-align:center;
+      &__logo{
+        width:150px;
+        height:50px;  
+      }
+      p.company{
+        font-size:12px;
+        color:rgb(158, 158, 158);
+        padding-bottom:50px;
+  
+
       }
     }
   }

--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -1,0 +1,302 @@
+//必須項目のアイコン
+@mixin absolute{
+  font-size:6px;
+  background-color: #ffb340;
+  color:white;
+  padding: 5px 5px 20px 5px;
+  margin-left:5px;
+  border-radius: 10px;
+  height: 20px;
+}
+//入寮項目名
+@mixin title{
+  font-size: 14px;
+  padding-bottom:0px;
+  margin-right:5px;
+}
+//入力項目の打ち込み箇所
+@mixin text-content{
+  width:300px;
+  height:40px;
+  border: 1px solid rgb(180, 179, 179);
+  font-size: 16px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+//ボタン
+@mixin btn{
+  font-size: 18px;
+  line-height: 48px;
+  color: #fff;
+  font-size: 18px;
+  margin-top:10px; 
+  text-decoration:none;
+}
+//ボタンの親要素
+@mixin parent-btn{
+  text-align: center;
+  width: 300px;
+  border-radius: 100px;
+  margin-top:60px;
+  cursor: pointer;
+}
+
+.edit{
+  &__box{
+    &__logo{
+      text-align:center;
+      padding:30px 0px;
+      &__img{
+        width:150px;
+        height:50px;
+      }
+    }
+    &__content{
+      background-color: rgb(244, 244, 244);
+      text-align: center;
+      padding: 30px 0px 0px 0px;
+      width:100vw;
+      &__inner{
+        background-color: white;
+        text-align:center;
+        padding:0px 20px;
+        width:700px;
+        margin: 0 auto; 
+        p.edit-title{
+          font-size:24px;
+          padding-top:50px;
+          font-weight: bold;
+        }
+        &__image{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.name{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          p.img-explain{
+            font-size: 12px;
+            padding-bottom:0px;
+            margin-right:5px;
+          }
+        }
+        &__name{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.name{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__introduction{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.introduction{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                width:600px;
+                height:300px;
+                border: 1px solid rgb(180, 179, 179);
+                font-size: 16px;
+                border-radius: 5px;
+                cursor: pointer;
+              }
+            }
+          }
+        }
+        &__price{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.price{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__category{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.category{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__brand{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.brand{
+              @include title;
+            }
+            p.absolute{
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__condition{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.condition{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__postage{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.postage{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__prefecture{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.prefecture{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              &__type{
+                @include text-content;
+              }
+            }
+          }
+        }
+        &__preparation{
+          &__explain{
+            display: flex;
+            justify-content: center;
+            padding-bottom:0px;
+            p.preparation{
+              @include title;
+            }
+            p.absolute{
+              @include absolute;
+            }
+          }
+          &__form__input{
+            &__text{
+              margin-bottom:0px;
+              &__type{
+                @include text-content;
+                margin-bottom:100px;
+              }
+            }
+          }
+        }
+      }
+    }
+    .edit__box__btn{
+      &__inner{
+        display: flex;
+        flex-direction:column;
+        align-items: center;
+        background-color: rgb(244, 244, 244);
+        padding-bottom:50px;
+        &__edit{
+          @include parent-btn;
+          background: #3CCACE;
+          border: 1px solid #3CCACE;;
+          .edit-btn{
+            @include btn;
+          }
+        }
+        &__return{
+          @include parent-btn;
+          background: #ffb340;
+          border: 1px solid #ffb340;
+          .return-btn{
+            @include btn;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,0 +1,99 @@
+.edit
+  .edit__box
+    .edit__box__logo
+      =image_tag "logo.png", alt: "FURIMA：", class: "edit__box__logo__img"
+    .edit__box__content
+      .edit__box__content__inner
+        %p.edit-title 商品情報の入力
+        -#商品名
+        .edit__box__content__inner__name
+          .edit__box__content__inner__name__explain
+            %p.name 商品画像
+            %p.absolute 必須
+          %p.img-explain 最大10枚まで
+          -#.field 
+            -#= form_for(resource, as: resource_name, url: root_path) do |f|
+            -#.field_input
+              -#= f.label :image
+            -#.field_input
+              -#= f.file_field :image
+        -#商品名
+        .edit__box__content__inner__name
+          .edit__box__content__inner__name__explain
+            %p.name 商品名
+            %p.absolute 必須
+          .edit__box__content__inner__name__form__input
+          = form_with local: true , class: "edit__box__content__inner__name__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__name__form__input__type", placeholder: "(例）マウンテンライトジャケット"
+            -#商品の説明
+        .edit__box__content__inner__feature
+          .edit__box__content__inner__name__feature
+            %p.feature 商品の説明
+            %p.absolute 必須
+          .edit__box__content__inner__feature__form__input
+          = form_with local: true , class: "edit__box__content__inner__feature__form__input__text" do |f|
+            = f.text_area :name, class: "edit__box__content__inner__feature__form__input__type", placeholder: "誰にでも伝わる内容を記入"
+            -#商品の金額
+        .edit__box__content__inner__price
+          .edit__box__content__inner__price__explain
+            %p.price 商品名
+            %p.absolute 必須
+          .edit__box__content__inner__price__form__input
+          = form_with local: true , class: "edit__box__content__inner__price__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__price__form__input__type", placeholder: "(例)5000円"
+            -#商品のカテゴリー
+        .edit__box__content__inner__category
+          .edit__box__content__inner__category__explain
+            %p.category カテゴリー
+            %p.absolute 必須
+          .edit__box__content__inner__category__form__input
+          = form_with local: true , class: "edit__box__content__inner__category__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__category__form__input__type", placeholder: "(例)ジャケット"
+            -#商品のブランド
+        .edit__box__content__inner__brand
+          .edit__box__content__inner__brand__explain
+            %p.brand ブランド
+            %p.absolute 
+          .edit__box__content__inner__brand__form__input
+          = form_with local: true , class: "edit__box__content__inner__brand__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__brand__form__input__type", placeholder: "(例)ザ　ノースフェイス"
+            -#商品の状態
+        .edit__box__content__inner__condition
+          .edit__box__content__inner__condition__explain
+            %p.condition 商品の状態
+            %p.absolute 必須
+          .edit__box__content__inner__condition__form__input
+          = form_with local: true , class: "edit__box__content__inner__condition__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__condition__form__input__type", placeholder: "(例)使用感有り"
+            -#配送量の負担
+        .edit__box__content__inner__postage
+          .edit__box__content__inner__postage__explain
+            %p.postage 配送料のご負担
+            %p.absolute 必須
+          .edit__box__content__inner__postage__form__input
+          = form_with local: true , class: "edit__box__content__inner__postage__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__postage__form__input__type", placeholder: "(例)出品者負担"
+            -#発送元の地域
+        .edit__box__content__inner__prefecture
+          .edit__box__content__inner__prefecture__explain
+            %p.prefecture 発送元の地域
+            %p.absolute 必須
+          .edit__box__content__inner__prefecture__form__input
+          = form_with local: true , class: "edit__box__content__inner__prefecture__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__prefecture__form__input__type", placeholder: "(例)東京都"
+            -#発送の日数
+        .edit__box__content__inner__preparation
+          .edit__box__content__inner__preparation__explain
+            %p.preparation 発送日の目安
+            %p.absolute 必須
+          .edit__box__content__inner__preparation__form__input
+          = form_with local: true , class: "edit__box__content__inner__preparation__form__input__text" do |f|
+            = f.text_field :name, class: "edit__box__content__inner__preparation__form__input__type", placeholder: "(例)4〜7日"
+    .edit__box__btn
+      .edit__box__btn__inner
+        .edit__box__btn__inner__edit
+          = link_to "変更する", root_path, method: :get, class: 'edit-btn'
+        .edit__box__btn__inner__return
+          = link_to "戻る", root_path, method: :get, class: 'return-btn'
+  .footer
+    = render "footer"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,6 +1,7 @@
 .edit
   .edit__box
     .edit__box__logo
+      = link_to root_path do
       =image_tag "logo.png", alt: "FURIMA：", class: "edit__box__logo__img"
     .edit__box__content
       .edit__box__content__inner
@@ -10,8 +11,9 @@
           .edit__box__content__inner__image__explain
             %p.image 商品画像
             %p.absolute 必須
-          %p.img-explain ※最大10枚まで表示可能です。
+          %p.img-explain ※最大10枚までアップロード可能です。
           .hidden-content
+            %p.dragdrop  ドラッグアンドドロップ<br>またはクリックしてファイルをダウンロード
             -#= form_with local:true , root_path,class"img-picture"do |f|
               -#= f.fields_for :images do |i|
               -#= i.file_field :image, class: "hidden-field"
@@ -38,7 +40,7 @@
             -#商品の金額
         .edit__box__content__inner__price
           .edit__box__content__inner__price__explain
-            %p.price 商品名
+            %p.price 販売価格
             %p.absolute 必須
           .edit__box__content__inner__price__form__input
           = form_with local: true , class: "edit__box__content__inner__price__form__input__text" do |f|
@@ -97,31 +99,14 @@
           = link_to "出品する", root_path, method: :get, class: 'edit-btn'
         .edit__box__btn__inner__return
           = link_to "戻る", root_path, method: :get, class: 'return-btn'
-  .bottomimage
-    =image_tag "bg-appBanner-pict.jpg", alt: "no-image", class: "bottomimage__visual"
-    .bottomimage__visual__content 誰でもかんたん、人生を変えるフリマアプリ
-    .bottomimage__visual__text  今すぐ無料ダウンロード！
-  -# 企業概要
-.bottom
-  .bottom__inner
-    .bottom__inner__box
-      .bottom__inner__box__content--one
-        .bottom__inner__box__content--one--title1  FURIMAについて
-        .bottom__inner__box__content--one--click1 会社概要（会社運営）
-        .bottom__inner__box__content--one--click2 プライバシーポリシー
-        .bottom__inner__box__content--one--click3 FURIMA利用規約
-        .bottom__inner__box__content--one--click4 ポイントに関する特約
-      .bottom__inner__box__content--two
-        .bottom__inner__box__content--two--title2  FURIMAを見る
-        .bottom__inner__box__content--two--click1 カテゴリー一覧
-        .bottom__inner__box__content--two--click2 ブランド一覧
-      .bottom__inner__box__content--three
-        .bottom__inner__box__content--three--title3  ヘルプ＆ガイド
-        .bottom__inner__box__content--three--click1 FURIMAガイド
-        .bottom__inner__box__content--three--click2 FURIMAロゴ利用ガイドライン
-        .bottom__inner__box__content--three--click3 お知らせ
-    .bottom__inner__image
-      .bottom__inner__image__img
-        =image_tag "logo-white.png", alt: "no-image", class: "bottom__inner__image__img__logo"
-      .bottom__inner__image__company  ©️FURIMA
+  .edit__footer
+    .edit__footer__box
+      %p.footer-rule プライバシーポリシー
+      %p.footer-rule FURIMA利用規約
+      %p.footer-rule 特定商取引に関する表記
+    .edit__footer__img
+      =image_tag "logo-white.png", alt: "FURIMA：", class: "edit__footer__img__logo"
+      %p.company  ©️FURIMA
+    
+
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -6,17 +6,19 @@
       .edit__box__content__inner
         %p.edit-title 商品情報の入力
         -#商品名
-        .edit__box__content__inner__name
-          .edit__box__content__inner__name__explain
-            %p.name 商品画像
+        .edit__box__content__inner__image
+          .edit__box__content__inner__image__explain
+            %p.image 商品画像
             %p.absolute 必須
-          %p.img-explain 最大10枚まで
-          -#.field 
-            -#= form_for(resource, as: resource_name, url: root_path) do |f|
-            -#.field_input
-              -#= f.label :image
-            -#.field_input
-              -#= f.file_field :image
+          %p.img-explain ※最大10枚まで表示可能です。
+          .hidden-content
+            -#= form_with local:true , root_path,class"img-picture"do |f|
+              -#= f.fields_for :images do |i|
+              -#= i.file_field :image, class: "hidden-field"
+              -#%input{class:"hidden-field", type: "file", name: "item[images_attributes][1][image]", id: "item_images_attributes_1_image" }
+              -#%input{class:"hidden-field", type: "file", name: "item[images_attributes][2][image]", id: "item_images_attributes_2_image" }
+              -#%input{class:"hidden-field", type: "file", name: "item[images_attributes][3][image]", id: "item_images_attributes_3_image" }
+              -#%input{class:"hidden-field", type: "file", name: "item[images_attributes][4][image]", id: "item_images_attributes_4_image" }
         -#商品名
         .edit__box__content__inner__name
           .edit__box__content__inner__name__explain
@@ -24,15 +26,15 @@
             %p.absolute 必須
           .edit__box__content__inner__name__form__input
           = form_with local: true , class: "edit__box__content__inner__name__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__name__form__input__type", placeholder: "(例）マウンテンライトジャケット"
+            = f.text_field :name, class: "edit__box__content__inner__name__form__input__text__type", placeholder: "(例）マウンテンライトジャケット"
             -#商品の説明
-        .edit__box__content__inner__feature
-          .edit__box__content__inner__name__feature
-            %p.feature 商品の説明
+        .edit__box__content__inner__introduction
+          .edit__box__content__inner__introduction__explain
+            %p.introduction 商品の説明
             %p.absolute 必須
-          .edit__box__content__inner__feature__form__input
-          = form_with local: true , class: "edit__box__content__inner__feature__form__input__text" do |f|
-            = f.text_area :name, class: "edit__box__content__inner__feature__form__input__type", placeholder: "誰にでも伝わる内容を記入"
+          .edit__box__content__inner__introduction__form__input
+          = form_with local: true , class: "edit__box__content__inner__introduction__form__input__text" do |f|
+            = f.text_area :name, class: "edit__box__content__inner__introduction__form__input__text__type", placeholder: "(例)2年前に購入した、一番人気のケルプタンカラーのジャケットです。お店で試着して以来着用しておらずタグもついています。"
             -#商品の金額
         .edit__box__content__inner__price
           .edit__box__content__inner__price__explain
@@ -40,7 +42,7 @@
             %p.absolute 必須
           .edit__box__content__inner__price__form__input
           = form_with local: true , class: "edit__box__content__inner__price__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__price__form__input__type", placeholder: "(例)5000円"
+            = f.text_field :name, class: "edit__box__content__inner__price__form__input__text__type", placeholder: "(例)5000円"
             -#商品のカテゴリー
         .edit__box__content__inner__category
           .edit__box__content__inner__category__explain
@@ -48,7 +50,7 @@
             %p.absolute 必須
           .edit__box__content__inner__category__form__input
           = form_with local: true , class: "edit__box__content__inner__category__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__category__form__input__type", placeholder: "(例)ジャケット"
+            = f.text_field :name, class: "edit__box__content__inner__category__form__input__text__type", placeholder: "(例)ジャケット"
             -#商品のブランド
         .edit__box__content__inner__brand
           .edit__box__content__inner__brand__explain
@@ -56,7 +58,7 @@
             %p.absolute 
           .edit__box__content__inner__brand__form__input
           = form_with local: true , class: "edit__box__content__inner__brand__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__brand__form__input__type", placeholder: "(例)ザ　ノースフェイス"
+            = f.text_field :name, class: "edit__box__content__inner__brand__form__input__text__type", placeholder: "(例)ザ　ノースフェイス"
             -#商品の状態
         .edit__box__content__inner__condition
           .edit__box__content__inner__condition__explain
@@ -64,7 +66,7 @@
             %p.absolute 必須
           .edit__box__content__inner__condition__form__input
           = form_with local: true , class: "edit__box__content__inner__condition__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__condition__form__input__type", placeholder: "(例)使用感有り"
+            = f.text_field :name, class: "edit__box__content__inner__condition__form__input__text__type", placeholder: "(例)使用感有り"
             -#配送量の負担
         .edit__box__content__inner__postage
           .edit__box__content__inner__postage__explain
@@ -72,7 +74,7 @@
             %p.absolute 必須
           .edit__box__content__inner__postage__form__input
           = form_with local: true , class: "edit__box__content__inner__postage__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__postage__form__input__type", placeholder: "(例)出品者負担"
+            = f.text_field :name, class: "edit__box__content__inner__postage__form__input__text__type", placeholder: "(例)出品者負担"
             -#発送元の地域
         .edit__box__content__inner__prefecture
           .edit__box__content__inner__prefecture__explain
@@ -80,7 +82,7 @@
             %p.absolute 必須
           .edit__box__content__inner__prefecture__form__input
           = form_with local: true , class: "edit__box__content__inner__prefecture__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__prefecture__form__input__type", placeholder: "(例)東京都"
+            = f.text_field :name, class: "edit__box__content__inner__prefecture__form__input__text__type", placeholder: "(例)東京都"
             -#発送の日数
         .edit__box__content__inner__preparation
           .edit__box__content__inner__preparation__explain
@@ -88,12 +90,38 @@
             %p.absolute 必須
           .edit__box__content__inner__preparation__form__input
           = form_with local: true , class: "edit__box__content__inner__preparation__form__input__text" do |f|
-            = f.text_field :name, class: "edit__box__content__inner__preparation__form__input__type", placeholder: "(例)4〜7日"
+            = f.text_field :name, class: "edit__box__content__inner__preparation__form__input__text__type", placeholder: "(例)4〜7日"
     .edit__box__btn
       .edit__box__btn__inner
         .edit__box__btn__inner__edit
-          = link_to "変更する", root_path, method: :get, class: 'edit-btn'
+          = link_to "出品する", root_path, method: :get, class: 'edit-btn'
         .edit__box__btn__inner__return
           = link_to "戻る", root_path, method: :get, class: 'return-btn'
-  .footer
-    = render "footer"
+  .bottomimage
+    =image_tag "bg-appBanner-pict.jpg", alt: "no-image", class: "bottomimage__visual"
+    .bottomimage__visual__content 誰でもかんたん、人生を変えるフリマアプリ
+    .bottomimage__visual__text  今すぐ無料ダウンロード！
+  -# 企業概要
+.bottom
+  .bottom__inner
+    .bottom__inner__box
+      .bottom__inner__box__content--one
+        .bottom__inner__box__content--one--title1  FURIMAについて
+        .bottom__inner__box__content--one--click1 会社概要（会社運営）
+        .bottom__inner__box__content--one--click2 プライバシーポリシー
+        .bottom__inner__box__content--one--click3 FURIMA利用規約
+        .bottom__inner__box__content--one--click4 ポイントに関する特約
+      .bottom__inner__box__content--two
+        .bottom__inner__box__content--two--title2  FURIMAを見る
+        .bottom__inner__box__content--two--click1 カテゴリー一覧
+        .bottom__inner__box__content--two--click2 ブランド一覧
+      .bottom__inner__box__content--three
+        .bottom__inner__box__content--three--title3  ヘルプ＆ガイド
+        .bottom__inner__box__content--three--click1 FURIMAガイド
+        .bottom__inner__box__content--three--click2 FURIMAロゴ利用ガイドライン
+        .bottom__inner__box__content--three--click3 お知らせ
+    .bottom__inner__image
+      .bottom__inner__image__img
+        =image_tag "logo-white.png", alt: "no-image", class: "bottom__inner__image__img__logo"
+      .bottom__inner__image__company  ©️FURIMA
+


### PR DESCRIPTION
## WHAT
商品出品画面マークアップ。
（JSはいったん未着手で進めていく）
## WHY
出品画面を早期に着手することで、
その後の一覧画面や商品詳細、編集、削除の実装を行うことができるようにする。

商品の入力は、itemsテーブルとimagesテーブルの２つ。
itemsテーブルのカラムは、ブランド以外は全て必須。
imagesテーブルの画像は必須。最大１０枚まで、登録可能。
出品画面と、商品編集画面がほとんど同じになる為、それを加味した上でマークアップをしていく。